### PR TITLE
Add information about auth_gss_format_full switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ The module has following directives:
 
 - auth_gss_service_name: what service name to use when acquiring
   credentials. (TOFIX: HTTP but should be a list in case of some other
-  browsers wanting perhaps khttp or http)
+  browsers wanting perhaps khttp or http),
+
+- auth_gss_format_full: "on"/"off", default "off", when "on" realm name will not
+  be stripped from $remote_user variable
 
 FIXME: for now they are all merely location specific. i.e. no way to
 specify main or per server defaults, except for ...


### PR DESCRIPTION
This could be useful when someone wants to have a full $remote_user
variable in format user@realm.name which can be further passed to an
application.

Ref #2
